### PR TITLE
index.d.ts: SemanticICONS: add missing 'file text outline'

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1892,6 +1892,7 @@ export type SemanticICONS =
   | 'feed'
   | 'female homosexual'
   | 'file text'
+  | 'file text outline'
   | 'find'
   | 'first aid'
   | 'fork'


### PR DESCRIPTION
Icon "file text outline" exists in the code but not in the `SemanticICONS` type.

This PR adds the missing string literal to the `SemanticICONS` type.

Left (highlighted):
`<Icon name="file text outline" />`

Right:
`<Icon name="file text" />`

<img width="68" alt="sh-602-prod-fr2 2018-07-10 12-38-17" src="https://user-images.githubusercontent.com/32278124/42505152-2feaeda0-843e-11e8-8c86-0f80e4a3dfee.png">
